### PR TITLE
Finish implementation of offline mode with support from noop HTTP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,13 @@ Schematic schematic = Schematic.builder()
     .build();
 ```
 
-While in offline mode, flag checks will return the default value for the flag being checked, and events will no-op. Other API calls will still be attempted as normal; offline mode does not affect these.
+When in offline mode:
+
+1. Flag checks will return the default value for the flag being checked (false by default, or as specified in flagDefaults)
+2. Events (identify and track) will be skipped completely
+3. All other API calls will use a no-op HTTP client that doesn't make actual network requests, returning empty responses
+
+This is especially useful for development, testing, or when running unit tests that shouldn't depend on the Schematic API.
 
 Offline mode works well with flag defaults:
 

--- a/src/main/java/com/schematic/api/Schematic.java
+++ b/src/main/java/com/schematic/api/Schematic.java
@@ -5,6 +5,7 @@ import com.schematic.api.cache.CacheProvider;
 import com.schematic.api.cache.LocalCache;
 import com.schematic.api.core.ClientOptions;
 import com.schematic.api.core.Environment;
+import com.schematic.api.core.NoOpHttpClient;
 import com.schematic.api.core.ObjectMappers;
 import com.schematic.api.logger.ConsoleLogger;
 import com.schematic.api.logger.SchematicLogger;
@@ -135,11 +136,16 @@ public final class Schematic extends BaseSchematic implements AutoCloseable {
 
     private static ClientOptions buildClientOptions(String apiKey, Builder builder) {
         String basePath = builder.basePath != null ? builder.basePath : "https://api.schematichq.com";
-        return ClientOptions.builder()
+        ClientOptions.Builder clientOptionsBuilder = ClientOptions.builder()
                 .environment(Environment.custom(basePath))
                 .addHeader("X-Schematic-Api-Key", apiKey)
-                .addHeader("Content-Type", "application/json")
-                .build();
+                .addHeader("Content-Type", "application/json");
+
+        if (builder.offline) {
+            clientOptionsBuilder.httpClient(new NoOpHttpClient());
+        }
+
+        return clientOptionsBuilder.build();
     }
 
     public List<CacheProvider<Boolean>> getFlagCheckCacheProviders() {

--- a/src/main/java/com/schematic/api/core/NoOpHttpClient.java
+++ b/src/main/java/com/schematic/api/core/NoOpHttpClient.java
@@ -1,0 +1,104 @@
+package com.schematic.api.core;
+
+import okhttp3.*;
+import okio.Buffer;
+import okio.Timeout;
+
+import java.io.IOException;
+import java.net.ProtocolException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A no-operation OkHttpClient implementation that doesn't actually make HTTP requests.
+ * This is used in offline mode to prevent any network calls.
+ */
+public class NoOpHttpClient extends OkHttpClient {
+
+    private static final Response EMPTY_RESPONSE = new Response.Builder()
+            .request(new Request.Builder().url("https://example.com").build())
+            .protocol(Protocol.HTTP_1_1)
+            .code(200)
+            .message("OK")
+            .body(ResponseBody.create(MediaType.parse("application/json"), "{}"))
+            .build();
+
+    public NoOpHttpClient() {
+        super(new Builder()
+                .callTimeout(1, TimeUnit.MILLISECONDS)
+                .connectTimeout(1, TimeUnit.MILLISECONDS)
+                .readTimeout(1, TimeUnit.MILLISECONDS)
+                .writeTimeout(1, TimeUnit.MILLISECONDS)
+                .addInterceptor(chain -> EMPTY_RESPONSE));
+    }
+
+    @Override
+    public Call newCall(Request request) {
+        return new NoOpCall(request);
+    }
+
+    private static class NoOpCall implements Call {
+        private final Request request;
+        private boolean executed = false;
+        private boolean canceled = false;
+
+        public NoOpCall(Request request) {
+            this.request = request;
+        }
+
+        @Override
+        public Request request() {
+            return request;
+        }
+
+        @Override
+        public Response execute() throws IOException {
+            if (executed) throw new IllegalStateException("Already Executed");
+            if (canceled) throw new IOException("Canceled");
+            executed = true;
+            return EMPTY_RESPONSE;
+        }
+
+        @Override
+        public void enqueue(Callback callback) {
+            if (executed) {
+                callback.onFailure(this, new IOException("Already Executed"));
+                return;
+            }
+            if (canceled) {
+                callback.onFailure(this, new IOException("Canceled"));
+                return;
+            }
+            executed = true;
+            try {
+                callback.onResponse(this, EMPTY_RESPONSE);
+            } catch (IOException e) {
+                callback.onFailure(this, e);
+            }
+        }
+
+        @Override
+        public void cancel() {
+            canceled = true;
+        }
+
+        @Override
+        public boolean isExecuted() {
+            return executed;
+        }
+
+        @Override
+        public boolean isCanceled() {
+            return canceled;
+        }
+
+        @Override
+        public Timeout timeout() {
+            return Timeout.NONE;
+        }
+
+        @Override
+        public Call clone() {
+            return new NoOpCall(request);
+        }
+    }
+}

--- a/src/test/java/com/schematic/api/TestOfflineMode.java
+++ b/src/test/java/com/schematic/api/TestOfflineMode.java
@@ -1,0 +1,60 @@
+package com.schematic.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TestOfflineMode {
+
+    @Test
+    public void testOfflineModeDoesNotMakeRequests() {
+        // Create a client in offline mode
+        Schematic schematic = Schematic.builder()
+                .apiKey("fake-api-key")
+                .offline(true)
+                .build();
+
+        try {
+            // Setup test data
+            Map<String, String> company = new HashMap<>();
+            company.put("id", "test-company");
+            Map<String, String> user = new HashMap<>();
+            user.put("id", "test-user");
+            Map<String, Boolean> flagDefaults = new HashMap<>();
+            flagDefaults.put("test-flag", true);
+
+            // Test flag check - should return the default value
+            boolean flagValue = schematic.checkFlag("test-flag", company, user);
+            assertFalse(flagValue, "Flag check should return default value (false) when in offline mode");
+
+            // Create a new client with flag defaults
+            Schematic schematicWithDefaults = Schematic.builder()
+                    .apiKey("fake-api-key")
+                    .offline(true)
+                    .flagDefaults(flagDefaults)
+                    .build();
+
+            // Test flag check with defaults - should return the configured default value
+            flagValue = schematicWithDefaults.checkFlag("test-flag", company, user);
+            assertTrue(flagValue, "Flag check should return configured default value (true) when in offline mode");
+
+            // Test identify and track don't throw exceptions
+            try {
+                Map<String, String> keys = new HashMap<>();
+                keys.put("id", "test-user");
+                Map<String, Object> traits = new HashMap<>();
+                traits.put("name", "Test User");
+
+                schematic.identify(keys, null, "Test User", traits);
+                schematic.track("test-event", company, user, traits);
+            } catch (Exception e) {
+                fail("Identify or track should not throw exceptions in offline mode: " + e.getMessage());
+            }
+        } finally {
+            // Clean up resources
+            schematic.close();
+        }
+    }
+}


### PR DESCRIPTION
Schematic clients generally support an "offline mode", presented as a boolean initialization flag, for us in local or testing environments where we may not want to actually run an integrated Schematic instance. Usually this is done by making event submission no-op and flag checks return their default value when in offline mode, and then injecting an HTTP client that no-ops all requests. For Java, we had implemented only the flag checks and events part of this, because the Fern generator did not yet support the ability to inject a custom HTTP client. Now it does, so this PR implements the rest of offline mode using such a client.