### PR TITLE
docs: fix dead links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Using Maven in `pom.xml`:
 </dependency>
 ```
 
-2. [Issue an API key](https://docs.schematichq.com/quickstart#create-an-api-key) for the appropriate environment using the [Schematic app](https://app.schematichq.com/settings/api-keys).
+2. [Issue an API key](https://docs.schematichq.com/quickstart/account-setup#2-create-your-api-keys) for the appropriate environment using the [Schematic app](https://app.schematichq.com/settings/api-keys).
 
 3. Using this secret key, initialize a client in your application:
 


### PR DESCRIPTION
The docs quickstart was split into a dashboard track and a code track, which removed the `#create-an-api-key` heading. The README linked to it, so that link now lands on the quickstart page with no anchor to jump to.

Points at the heading where API key creation actually lives now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)